### PR TITLE
fix reused http socket status code

### DIFF
--- a/minihttp.cpp
+++ b/minihttp.cpp
@@ -1005,6 +1005,7 @@ bool HttpSocket::_OpenRequest(const Request& req)
         traceprint("HttpSocket::_OpenRequest(): _inProgress == true, should not be called.");
         return false;
     }
+    _status = 0;
     if(req.useSSL && !hasSSL())
     {
         traceprint("HttpSocket::_OpenRequest(): Is an SSL connection, but SSL was not inited, doing that now\n");
@@ -1018,7 +1019,6 @@ bool HttpSocket::_OpenRequest(const Request& req)
         return false;
     _inProgress = true;
     _curRequest = req;
-    _status = 0;
     return true;
 }
 


### PR DESCRIPTION
Test code:
```c++

class HttpTestSocket : public minihttp::HttpSocket
{
    virtual void _OnRecv(void *buf, unsigned int size) {}
};

int main(int argc, char *argv[])
{
    // On *NIX systems, don't signal writing to a closed socket.
    signal(SIGPIPE, SIG_IGN);

    minihttp::InitNetwork();
    atexit(minihttp::StopNetwork);

    HttpTestSocket *ht = new HttpTestSocket;

    for (int n = 1; n < argc; ++n) {
        printf("Download(\"%s\")\n", argv[n]);
        ht->Download(argv[n]);
        do ht->update();
        while (ht->isOpen() && ht->HasPendingTask());
        printf("IsSuccess()? %c\n", ht->IsSuccess() ? 'y' : 'n');
    }

    return 0;
}
```

Output on master:
```bash
▸ g++ -D_DEBUG test.cpp minihttp.cpp -o test && ./test 0.0.0.0:66666 http://example.com 0.0.0.0:66666
Download("0.0.0.0:66666")
HttpSocket::_EnqueueOrSend, forceQueue = 0
HTTP: Open request for immediate send.
TcpSocket::open(): host = [0.0.0.0], port = 66666
CONNECT ERROR: Connection refused
IsSuccess()? n
Download("http://example.com")
HttpSocket::_EnqueueOrSend, forceQueue = 0
HTTP: Open request for immediate send.
TcpSocket::open(): host = [example.com], port = 80
HDR: content-type: text/html
HDR: etag: "84238dfc8092e5d9c0dac8ef93371a07:1736799080.121134"
HDR: last-modified: Mon, 13 Jan 2025 20:11:20 GMT
HDR: cache-control: max-age=1757
HDR: date: Sat, 14 Jun 2025 12:40:40 GMT
HDR: content-length: 1256
HDR: connection: close
HDR: x-n: S
Got HTTP Status 200
TcpSocket::close
HttpSocket::_FinishRequest
... in progress. redirecting = 0
TcpSocket::close
HttpSocket::_FinishRequest
IsSuccess()? y
Download("0.0.0.0:66666")
HttpSocket::_EnqueueOrSend, forceQueue = 0
HTTP: Open request for immediate send.
TcpSocket::open(): host = [0.0.0.0], port = 66666
CONNECT ERROR: Connection refused
IsSuccess()? y
```

Expected: `IsSuccess()` should return `false` after the third download.