### PR TITLE
fix close on invalid descriptor

### DIFF
--- a/minihttp.cpp
+++ b/minihttp.cpp
@@ -388,6 +388,9 @@ void TcpSocket::close(void)
 
     _OnCloseInternal();
 
+    if(!SOCKETVALID(_s))
+        return;
+
 #ifdef MINIHTTP_USE_MBEDTLS
     if(_sslctx)
         ((SSLCtx*)_sslctx)->reset();


### PR DESCRIPTION
Test code:
```c++

class HttpTestSocket : public minihttp::HttpSocket
{
    virtual void _OnRecv(void *buf, unsigned int size) {}
};

int main(int argc, char *argv[])
{
    // On *NIX systems, don't signal writing to a closed socket.
    signal(SIGPIPE, SIG_IGN);

    minihttp::InitNetwork();
    atexit(minihttp::StopNetwork);

    HttpTestSocket *ht = new HttpTestSocket;

    ht->Download("http://example.com");
    ht->close();

    return 0;
}
```

Strace output on master:
```bash
▸ g++ -D_DEBUG test.cpp minihttp.cpp -o test && strace -e close ./test
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
HttpSocket::_EnqueueOrSend, forceQueue = 0
HTTP: Open request for immediate send.
TcpSocket::open(): host = [example.com], port = 80
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
close(3)                                = 0
TcpSocket::close
HttpSocket::_FinishRequest
... in progress. redirecting = 0
TcpSocket::close
HttpSocket::_FinishRequest
close(3)                                = 0
close(-1)                               = -1 EBADF (Bad file descriptor)
+++ exited with 0 +++
```